### PR TITLE
Redirect if not logged in

### DIFF
--- a/src/app/assets/javascripts/angular/app.js
+++ b/src/app/assets/javascripts/angular/app.js
@@ -4,7 +4,8 @@
   var app = angular
         .module('nexbus', ['ngRoute', 'ngAnimate', 'ngTouch', 'templates']);
 
-  app.config(['$routeProvider', function($routeProvider){
+  app
+    .config(['$routeProvider', function($routeProvider, checkLoggedIn){
     $routeProvider
       .when('/', {
         templateUrl: 'ng-index.html',
@@ -16,13 +17,28 @@
       })
       .when('/main', {
         templateUrl: 'card.html',
-        controller: 'CardController'
+        controller: 'CardController',
+        resolve: {
+          authenticated: function(checkLoggedIn) {
+            return checkLoggedIn();
+          }
+        }
       })
       .when('/location', {
         templateUrl: 'location.html',
-        controller: 'LocationController'
+        controller: 'LocationController',
+        resolve: {
+          authenticated: function(checkLoggedIn) {
+            return checkLoggedIn();
+          }
+        }
       })
-  }]);
+    }])
+    .run(function ($rootScope) {
+      $rootScope.$on("$routeChangeError", function (event, current, previous, rejection) {
+        console.log(rejection);
+      });
+    });
 
   app.directive('nbTimings', function() {
     return {

--- a/src/app/assets/javascripts/angular/app.js
+++ b/src/app/assets/javascripts/angular/app.js
@@ -7,12 +7,11 @@
   app
     .config(['$routeProvider', function($routeProvider, checkLoggedIn){
     $routeProvider
-      .when('/', {
-        templateUrl: 'ng-index.html',
+      .when('/#', {
         controller: 'MainController'
       })
       .when('/login', {
-        templateUrl: 'login.html',
+        templateUrl: 'ng-index.html',
         controller: 'LoginController'
       })
       .when('/main', {
@@ -38,7 +37,7 @@
     .run(function ($rootScope, $location) {
       $rootScope.$on("$routeChangeError", function (event, current, previous, rejection) {
         console.log(rejection);
-        $location.path('/');
+        $location.path('/login');
       });
     });
 

--- a/src/app/assets/javascripts/angular/app.js
+++ b/src/app/assets/javascripts/angular/app.js
@@ -33,10 +33,12 @@
           }
         }
       })
+      .otherwise({redirectTo: '/location'});
     }])
-    .run(function ($rootScope) {
+    .run(function ($rootScope, $location) {
       $rootScope.$on("$routeChangeError", function (event, current, previous, rejection) {
         console.log(rejection);
+        $location.path('/');
       });
     });
 

--- a/src/app/assets/javascripts/angular/controllers/mainController.js
+++ b/src/app/assets/javascripts/angular/controllers/mainController.js
@@ -1,9 +1,18 @@
 (function() {
   angular
   .module('nexbus')
-  .controller('MainController', ["$scope", MainController]);
-
-function MainController($scope) {
-
-}
+  .controller('MainController', function MainController($scope, $location, $http) {
+    $http.get('/auth/signed_in').
+      then(function(res) {
+        if (res.data.user !== null) {
+          console.log('logged in');
+          $location.path('/location');
+        } else {
+          console.log('not logged in');
+          $location.path('/login');
+        }
+      }, function(err) {
+        console.log(err);
+      });
+  })
 })();

--- a/src/app/assets/javascripts/angular/services/checkLoggedIn.js
+++ b/src/app/assets/javascripts/angular/services/checkLoggedIn.js
@@ -1,18 +1,24 @@
 (function() {
   angular
     .module('nexbus')
-    .factory('loggedIn', function($q, $http) {
+    .factory('checkLoggedIn', function($q, $http) {
       return function() {
         var deferred = $q.defer();
 
         $http.get('/auth/signed_in').
           then(function(res) {
             if (res) {
-              deferred.resolve();
+              console.log("Signed In");
+              console.log(res);
+              deferred.resolve("Signed In");
             } else {
-              deferred.reject();
+              console.log("not signed in");
+              console.log(res);
+              deferred.reject("Not Signed In");
             }
-          }, function(err) {});
+          }, function(err) {
+            console.log(err);
+          });
       }
     });
 })();

--- a/src/app/assets/javascripts/angular/services/checkLoggedIn.js
+++ b/src/app/assets/javascripts/angular/services/checkLoggedIn.js
@@ -1,0 +1,18 @@
+(function() {
+  angular
+    .module('nexbus')
+    .factory('loggedIn', function($q, $http) {
+      return function() {
+        var deferred = $q.defer();
+
+        $http.get('/auth/signed_in').
+          then(function(res) {
+            if (res) {
+              deferred.resolve();
+            } else {
+              deferred.reject();
+            }
+          }, function(err) {});
+      }
+    });
+})();

--- a/src/app/assets/javascripts/angular/services/checkLoggedIn.js
+++ b/src/app/assets/javascripts/angular/services/checkLoggedIn.js
@@ -7,7 +7,7 @@
 
         $http.get('/auth/signed_in').
           then(function(res) {
-            if (res) {
+            if (res.data.user !== null) {
               console.log("Signed In");
               console.log(res);
               deferred.resolve("Signed In");

--- a/src/app/assets/javascripts/angular/services/checkLoggedIn.js
+++ b/src/app/assets/javascripts/angular/services/checkLoggedIn.js
@@ -3,18 +3,18 @@
     .module('nexbus')
     .factory('checkLoggedIn', function($q, $http) {
       return function() {
+        // Async
         var deferred = $q.defer();
 
-        $http.get('/auth/signed_in').
+        // Send GET request to check whether user is signed in
+        return $http.get('/auth/signed_in').
           then(function(res) {
             if (res.data.user !== null) {
-              console.log("Signed In");
-              console.log(res);
-              deferred.resolve("Signed In");
+              deferred.resolve();
+              return deferred.promise;
             } else {
-              console.log("not signed in");
-              console.log(res);
               deferred.reject("Not Signed In");
+              return deferred.promise;
             }
           }, function(err) {
             console.log(err);

--- a/src/app/controllers/sessions_controller.rb
+++ b/src/app/controllers/sessions_controller.rb
@@ -11,4 +11,8 @@ class SessionsController < ApplicationController
     redirect_to '#'
   end
 
+  def signed_in
+    render json: { user: session[:user_id] }
+  end
+
 end

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -48,4 +48,5 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback' => 'sessions#create'
   get 'auth/failure' => redirect('/')
   get 'signout' => 'sessions#destroy'
+  get 'auth/signed_in' => 'session#signed_in'
 end

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
         post '/' => 'sessions#create'
       end
     end
-    get '/failure' => redirect('/')
+    get '/failure' => redirect('#')
     get '/signed_in' => 'sessions#signed_in'
   end
 

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -53,7 +53,6 @@ Rails.application.routes.draw do
     end
     get '/failure' => redirect('#')
     get '/signed_in' => 'sessions#signed_in'
+    post '/signout' => 'sessions#destroy'
   end
-
-  get 'signout' => 'sessions#destroy'
 end

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -44,9 +44,16 @@ Rails.application.routes.draw do
   end
 
   # Authentication Routes
-  get 'auth/:provider/callback' => 'sessions#create'
-  post 'auth/:provider/callback' => 'sessions#create'
-  get 'auth/failure' => redirect('/')
+  scope :auth do
+    scope '/:provider' do
+      scope '/callback' do
+        get '/' => 'sessions#create'
+        post '/' => 'sessions#create'
+      end
+    end
+    get '/failure' => redirect('/')
+    get '/signed_in' => 'sessions#signed_in'
+  end
+
   get 'signout' => 'sessions#destroy'
-  get 'auth/signed_in' => 'session#signed_in'
 end


### PR DESCRIPTION
Users who are logged in is now redirected to '/location' directly.
Users who are not logged in can only access '/login' page

To test: Remove Nexbus-Test 1 on fb, then close + reopen your browser.
It should be able to clear session automatically on live server, but not on localhost (fb deauth callback doesn't work on localhost)
We really need a sign out button though.

Some changes in file name (templates) might be required to make it more intuitive.
