### PR TITLE
Favorites

### DIFF
--- a/src/app/controllers/api/v1/favorite_stops_controller.rb
+++ b/src/app/controllers/api/v1/favorite_stops_controller.rb
@@ -6,16 +6,18 @@ module Api
 
       def index
         @favorites = FavoriteStop.where(user_id: current_user.id)
-        respond_with @favorites
+        @favorite_stops = @favorites.map { |f| f.stop }
+        respond_with @favorite_stops
       end
 
       def create
-        render json: FavoriteStop.create(stop: @stop, user: current_user)
+        @favorite_stop = FavoriteStop.create(stop: @stop, user: current_user)
+        respond_with({status: :favorited, stop: @stop})
       end
 
       def destroy
         FavoriteStop.where(stop_id: @stop.id, user_id: current_user.id).first.destroy
-        redirect_to @stop, notice: 'Stop no longer in favorites'
+        respond_with({status: :deleted})
       end
 
       def set_stop

--- a/src/app/controllers/api/v1/favorite_stops_controller.rb
+++ b/src/app/controllers/api/v1/favorite_stops_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    class FavoriteStopsController < ApplicationController
+      respond_to :json
+      before_action :set_stop
+
+      def index
+        @favorites = FavoriteStop.where(user_id: current_user.id)
+        respond_with @favorites
+      end
+
+      def create
+        render json: FavoriteStop.create(stop: @stop, user: current_user)
+      end
+
+      def destroy
+        FavoriteStop.where(stop_id: @stop.id, user_id: current_user.id).first.destroy
+        redirect_to @stop, notice: 'Stop no longer in favorites'
+      end
+
+      def set_stop
+        @stop = Stop.find(params[:stop_id] || params[:id])
+      end
+    end
+  end
+end
+

--- a/src/app/models/favorite_stop.rb
+++ b/src/app/models/favorite_stop.rb
@@ -1,0 +1,4 @@
+class FavoriteStop < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :stop
+end

--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ActiveRecord::Base
   DEFAULT_CREDIT = 100
   before_create :set_default_credit
 
+  has_many :favorite_stops
+
   def update_credit(amount)
     credit = amount
   end

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -41,6 +41,12 @@ Rails.application.routes.draw do
       scope :locations do
         get '/' => 'locations#nearby'
       end
+
+      scope :favorite_stops do
+        get '/' => 'favorite_stops#index'
+        post '/' => 'favorite_stops#create'
+        delete '/' => 'favorite_stops#destroy'
+      end
     end
   end
 

--- a/src/db/migrate/20150919174836_create_favorite_stops.rb
+++ b/src/db/migrate/20150919174836_create_favorite_stops.rb
@@ -1,0 +1,11 @@
+class CreateFavoriteStops < ActiveRecord::Migration
+  def change
+    create_table :favorite_stops do |t|
+      t.references :user, index: true, foreign_key: true, null: false
+      t.references :stop, null: false
+
+      t.timestamps null: false
+    end
+    add_index :favorite_stops, [:user_id, :stop_id], unique: true
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -11,10 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150910141712) do
+ActiveRecord::Schema.define(version: 20150919174836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorite_stops", force: :cascade do |t|
+    t.integer  "user_id",    null: false
+    t.integer  "stop_id",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "favorite_stops", ["user_id", "stop_id"], name: "index_favorite_stops_on_user_id_and_stop_id", unique: true, using: :btree
+  add_index "favorite_stops", ["user_id"], name: "index_favorite_stops_on_user_id", using: :btree
 
   create_table "services", force: :cascade do |t|
     t.string "name", null: false
@@ -60,5 +70,6 @@ ActiveRecord::Schema.define(version: 20150910141712) do
     t.datetime "updated_at",       null: false
   end
 
+  add_foreign_key "favorite_stops", "users"
   add_foreign_key "timings", "services"
 end


### PR DESCRIPTION
Favorites api can be accessed in `api/v1/favorite_stops/` endpoint and accepts `GET`, `POST`, `DELETE` commands.

When you `GET`, the endpoint will return an (possibly empty) array containing all stops favorited by that user.

When you `POST`, it will return `{status: created, stop: stop_object}` upon successful creation.

When you `DELETE`, it will return `{status: deleted}` upon successful deletion.

Precondition: user must be logged in.
